### PR TITLE
Add IRI to Manchester OWL Ontology: line

### DIFF
--- a/vn/generator.py
+++ b/vn/generator.py
@@ -288,7 +288,7 @@ class Header:
 				link = str(PREFIX_DICT[prefix])
 				returnstr += self.ontobj.gh.make_prefix(prefix, link)
 		returnstr += self.ontobj.gh.make_prefix(self.ontobj.ontology_name, self.ontobj.ontology)	
-		returnstr += "\nOntology: <:>\n\n"
+		returnstr += "\nOntology: <http://fakesite.org/>\n\n"
 		returnstr += "Annotations:\n\tdc:title \"" + str(self.ontobj.sys_name) + "\",\n\tdc:creator \"Visual Narrator\",\n\trdfs:comment \"Generated with Visual Narrator\"\n\n"
 		returnstr += "AnnotationProperty: dc:creator\n\n"
 		returnstr += "AnnotationProperty: dc:title\n\n"


### PR DESCRIPTION
The exported Manchester OWL (.omn) file couldn't be opened in Protege 5.5. I'm not sure if this is a version incompatibility issue or not, but the Manchester OWL "Ontology:" construct  seems to be the problem. The ontologyIRI field is optional, but I think it has to be a valid IRI if you include it ("<:>" is invalid?). I used an IRI I found elsewhere in the code.

We are using the "old" branch for compatibility, but the generator.py line is the same in master.